### PR TITLE
ci: remove merge_group trigger

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  merge_group:
 
 jobs:
   typecheck:


### PR DESCRIPTION
Merge groups are only available for org repos