### PR TITLE
chore: set package.json repository to an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
         }
     },
     "homepage": "https://github.com/SerenModz21/paste.gg#readme",
-    "repository": "git://github.com/SerenModz21/paste.gg.git",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/SerenModz21/paste.gg.git"
+    },
     "bugs": {
         "url": "https://github.com/SerenModz21/paste.gg/issues"
     },


### PR DESCRIPTION
Publint suggests that the repository should be an object instead of a string.

https://publint.dev/paste.gg@1.1.3
The field value isn't a valid shorthand value supported by npm. Consider using an object that references a repository.

https://publint.dev/rules#invalid_repository_value